### PR TITLE
Update FAQ with encryption hardware recommendations.rst

### DIFF
--- a/docs/Project and Community/FAQ.rst
+++ b/docs/Project and Community/FAQ.rst
@@ -31,6 +31,7 @@ The suggested hardware requirements are:
 -  8GB+ of memory for the best performance. It's perfectly possible to
    run with 2GB or less (and people do), but you'll need more if using
    deduplication.
+-  For ZFS native encryption a CPU with AES-NI is recommended. Better performance is achieved with a CPU that supports the MOVBE instruction, for AMD that is  the Excavator family and newer, for Intel that is the Haswell family and newer.
 
 Do I have to use ECC memory for ZFS?
 ------------------------------------


### PR DESCRIPTION
Let's make clear that people with older setups should not enable encryption if their CPUs are too old. AES-NI is extremely common but MOVBE less so and adding this requirement could prevent disappointments.

Encryption makes extensive use of AES-NI instructions as per: https://github.com/openzfs/zfs/commit/31b160f0a6c673c8f926233af2ed6d5354808393
If a CPU supports MOVBE that makes it even faster, though there is now some workaround for CPUs without: https://github.com/openzfs/zfs/commit/5b3b79559c3206ea5916cbdab72b88344aa6e9a2